### PR TITLE
Remove unused permissions from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,10 +11,7 @@
   },
   "permissions": [
     "tabs",
-    "activeTab",
-    "scripting",
     "webRequest",
-    "webNavigation",
     "sidePanel"
   ],
   "host_permissions": ["<all_urls>"],


### PR DESCRIPTION
Remove activeTab, scripting, and webNavigation permissions that are not used by any API calls in the extension codebase.